### PR TITLE
Resolve 'window is not defined' with webpack config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "6"
   - "8"
   - "10"
 sudo: false

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,7 +54,8 @@ function build() {
       output: {
         filename: `${exportFileName}.js`,
         libraryTarget: 'umd',
-        library: config.mainVarName
+        library: config.mainVarName,
+        globalObject: 'this'
       },
       mode: "production",
       externals: {},


### PR DESCRIPTION
Webpack adds a header script with variable 'window', which is undefined when executing on node.

https://github.com/markdalgleish/static-site-generator-webpack-plugin/issues/130